### PR TITLE
Root adjust

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders', { path: '/reminders'});
+ this.route('reminders', { path: '/reminders'});
 });
 
 export default Router;

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
- this.route('reminders', { path: '/reminders'});
+ this.route('reminders', {path: '/reminders'});
 });
 
 export default Router;

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders', { path: '/'});
+  this.route('reminders', { path: '/reminders'});
 });
 
 export default Router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   beforeModel(){
-    this.transitionTo('reminders')
+    this.transitionTo('reminders');
   }
-})
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel(){
+    this.transitionTo('reminders')
+  }
+})

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -13,7 +13,7 @@ test('viewing the homepage', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(currentURL(), '/');
+    assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.reminder-item').length, 5);
   });
 });


### PR DESCRIPTION
## Purpose

to redirect to /reminders on refresh

## Approach

changes routes from / to /reminders

### Learning

learned that replaceWith() deletes history and transitionTo() redirects while keeping history

### Open Questions and Pre-Merge TODOs
were not sure if to use transitionTo() or replaceWith() and how to tell when to use one over the other.

### Test coverage 
fixed failing test by expecting /reminders instead of /


### Follow-up tasks

- [Issue #3  ]

### Screenshots
#### After
[http://g.recordit.co/1c5bMdXLkt.gif]